### PR TITLE
UI fixes: nav, filters, local upload, and overview clarity

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -52,6 +52,16 @@ npm run dev
 
 Open **http://localhost:3001/** and **http://localhost:3001/health**.
 
+Run the web app with mock mode off so uploads hit this server:
+
+```bash
+# frontend/web/.env.local
+VITE_API_BASE_URL=http://localhost:3001
+VITE_USE_MOCK=false
+```
+
+Then `cd frontend/web && npm run dev` (http://localhost:5173). CORS allows the Vite dev origin.
+
 ## Deploy (AWS CDK)
 
 See **[README-deploy.md](./README-deploy.md)** for full steps (`cd backend/infra`, `npm install`, `cdk bootstrap`, `cdk deploy`, Vercel env).

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,7 +1,18 @@
 import { Hono } from "hono";
+import { cors } from "hono/cors";
 import { analyzeCsvBuffers, MAX_CSV_BYTES, isCsvFileName } from "./csvAnalyze.js";
 
 export const app = new Hono();
+
+app.use(
+  "*",
+  cors({
+    origin: (origin) => origin ?? "*",
+    allowHeaders: ["Content-Type", "Authorization", "Accept"],
+    allowMethods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+    maxAge: 300,
+  }),
+);
 
 app.get("/", (c) => {
   return c.json({

--- a/frontend/web/.env.example
+++ b/frontend/web/.env.example
@@ -1,7 +1,13 @@
 # Copy this file to `.env.local` and fill in values for your environment.
 # All vars are read at build time by Vite (must start with VITE_).
 
-# Base URL of the FinanceOS backend (API Gateway HTTP API URL from `cdk deploy`, output ApiUrl).
+# --- Local dev (frontend + backend both running) ---
+# VITE_API_BASE_URL=http://localhost:3001
+# VITE_USE_MOCK=false
+# Start backend: cd backend && npm run dev
+# Start frontend: cd frontend/web && npm run dev
+
+# --- Deployed API (API Gateway URL from `cdk deploy`, output ApiUrl) ---
 # Example: https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com
 # The Import page POSTs CSVs to `${VITE_API_BASE_URL}/api/analyze` when mock mode is off.
 # When empty, the frontend runs in mock mode and serves seeded data from `src/data/mockTransactions.js`.

--- a/frontend/web/src/components/common/NavbarActions.jsx
+++ b/frontend/web/src/components/common/NavbarActions.jsx
@@ -144,7 +144,7 @@ function NavbarActions() {
               {hasProfile ? displayName : "Create your profile"}
             </p>
             <p className="text-xs text-ink-500 dark:text-ink-400">
-              {hasProfile ? "View profile" : "Unlock AI insights"}
+              {hasProfile ? "View profile" : "Set up profile"}
             </p>
           </div>
           <ChevronDown

--- a/frontend/web/src/components/common/SettingsPopover.jsx
+++ b/frontend/web/src/components/common/SettingsPopover.jsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
 import { AnimatePresence, motion as Motion } from "framer-motion";
 import { Bell, Calendar, Moon, RotateCcw, Sun, Upload } from "lucide-react";
+import { usePageFilters } from "../../context/usePageFilters";
 import { useTransactions } from "../../context/useTransactions";
 import { useTheme } from "../../hooks/useTheme";
 import { formatMonth } from "../../utils/format";
@@ -9,11 +10,11 @@ import seed from "../../data/mockTransactions";
 function SettingsPopover({ open, onClose }) {
   const {
     months,
-    filters,
-    setFilters,
-    ALL_MONTHS_SENTINEL,
     replaceAll,
+    resetAllPageFilters,
+    ALL_MONTHS_SENTINEL,
   } = useTransactions();
+  const { filters, setFilters } = usePageFilters();
   const { theme, toggleTheme } = useTheme();
 
   const monthOptions = [
@@ -23,7 +24,7 @@ function SettingsPopover({ open, onClose }) {
 
   function handleReset() {
     replaceAll(seed);
-    setFilters((f) => ({ ...f, month: ALL_MONTHS_SENTINEL, categories: [], search: "" }));
+    resetAllPageFilters();
     onClose?.();
   }
 

--- a/frontend/web/src/components/dashboard/WelcomeHero.jsx
+++ b/frontend/web/src/components/dashboard/WelcomeHero.jsx
@@ -4,6 +4,7 @@ import { motion as Motion } from "framer-motion";
 import HeroCharacter from "./HeroCharacter";
 import CountUp from "../effects/CountUp";
 import { useTransactions } from "../../context/useTransactions";
+import { usePageFilters } from "../../context/usePageFilters";
 import { useProfile } from "../../hooks/useProfile";
 import { compareMonthOverMonth, totalSpend } from "../../utils/insights";
 import { classifyPersonality } from "../../utils/personality";
@@ -19,7 +20,8 @@ function greeting() {
 }
 
 function WelcomeHero() {
-  const { filtered, transactions } = useTransactions();
+  const { transactions } = useTransactions();
+  const { filtered } = usePageFilters("overview");
   const { profile, hasProfile } = useProfile();
   const total = totalSpend(filtered);
   const mom = compareMonthOverMonth(transactions);

--- a/frontend/web/src/components/layout/MobileFab.jsx
+++ b/frontend/web/src/components/layout/MobileFab.jsx
@@ -8,13 +8,13 @@ import ProfilePanel from "../profile/ProfilePanel";
 import seed from "../../data/mockTransactions";
 
 function MobileFab() {
-  const { replaceAll, setFilters, ALL_MONTHS_SENTINEL } = useTransactions();
+  const { replaceAll, resetAllPageFilters } = useTransactions();
   const [open, setOpen] = useState(false);
   const [profileOpen, setProfileOpen] = useState(false);
 
   function handleReset() {
     replaceAll(seed);
-    setFilters((f) => ({ ...f, month: ALL_MONTHS_SENTINEL, categories: [], search: "" }));
+    resetAllPageFilters();
     setOpen(false);
   }
 

--- a/frontend/web/src/components/layout/MobileNav.jsx
+++ b/frontend/web/src/components/layout/MobileNav.jsx
@@ -11,7 +11,30 @@ const SPEND_NAV = [
   { to: "/upload", label: "Upload", icon: Upload },
 ];
 
-const REAL_ESTATE_NAV = [{ to: "/house-sale", label: "House", icon: Home }];
+const REAL_ESTATE_NAV = [{ to: "/house-sale", label: "House Sale", icon: Home, comingSoon: true }];
+
+function MobileComingSoonItem({ label, icon }) {
+  return (
+    <span
+      aria-disabled="true"
+      title="House Sale — appear soon"
+      className="relative mx-auto flex max-w-[76px] cursor-not-allowed select-none flex-col items-center gap-0.5 rounded-2xl px-1.5 py-1.5 sm:px-2"
+    >
+      <span className="relative flex h-9 w-9 items-center justify-center rounded-full bg-brand-50 text-brand-600 ring-1 ring-brand-200/80 dark:bg-brand-950/40 dark:text-brand-300 dark:ring-brand-700/50">
+        {createElement(icon, { size: 18 })}
+        <span className="absolute -right-0.5 -top-0.5 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-gradient-to-br from-brand-600 to-violet-500 text-white shadow-brand">
+          <Sparkles size={8} strokeWidth={2.5} aria-hidden />
+        </span>
+      </span>
+      <span className="max-w-full text-center text-[9px] font-semibold leading-tight text-ink-700 dark:text-ink-100 sm:text-[10px]">
+        {label}
+      </span>
+      <span className="rounded-full bg-gradient-to-r from-brand-600 to-violet-500 px-1.5 py-px text-[7px] font-bold uppercase tracking-wide text-white">
+        Soon
+      </span>
+    </span>
+  );
+}
 
 function MobileNav() {
   return (
@@ -49,8 +72,11 @@ function MobileNav() {
           </li>
         ))}
         <li className="mx-0.5 h-8 w-px shrink-0 self-center bg-ink-200/90 dark:bg-ink-600" aria-hidden />
-        {REAL_ESTATE_NAV.map(({ to, label, icon, end }) => (
-          <li key={to} className="min-w-0 flex-1">
+        {REAL_ESTATE_NAV.map(({ to, label, icon, end, comingSoon }) => (
+          <li key={to} className="min-w-0 shrink-0">
+            {comingSoon ? (
+              <MobileComingSoonItem label={label} icon={icon} />
+            ) : (
             <NavLink
               to={to}
               end={end}
@@ -78,6 +104,7 @@ function MobileNav() {
                 </>
               )}
             </NavLink>
+            )}
           </li>
         ))}
       </ul>

--- a/frontend/web/src/components/layout/Sidebar.jsx
+++ b/frontend/web/src/components/layout/Sidebar.jsx
@@ -19,9 +19,38 @@ const NAV_SECTIONS = [
   {
     id: "real-estate",
     label: "Real estate",
-    items: [{ to: "/house-sale", label: "House Sale", icon: Home }],
+    items: [{ to: "/house-sale", label: "House Sale", icon: Home, comingSoon: true }],
   },
 ];
+
+function SidebarComingSoonItem({ label, icon }) {
+  return (
+    <span
+      aria-disabled="true"
+      title="House Sale — appear soon"
+      className="group relative block cursor-not-allowed select-none rounded-2xl p-[1px] bg-gradient-to-br from-brand-300/70 via-violet-300/50 to-brand-400/60 dark:from-brand-500/40 dark:via-violet-500/30 dark:to-brand-600/40"
+    >
+      <span className="relative flex items-center gap-3 rounded-[15px] bg-white/90 px-3 py-2.5 dark:bg-ink-900/90">
+        <span className="relative flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-brand-50 text-brand-600 ring-1 ring-brand-100 dark:bg-brand-950/50 dark:text-brand-300 dark:ring-brand-800/60">
+          {createElement(icon, { size: 16 })}
+          <Motion.span
+            aria-hidden
+            animate={{ scale: [1, 1.35, 1], opacity: [0.55, 0, 0.55] }}
+            transition={{ duration: 2.4, repeat: Infinity, ease: "easeInOut" }}
+            className="absolute inset-0 rounded-xl bg-brand-400/25"
+          />
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="block text-sm font-semibold text-ink-700 dark:text-ink-100">{label}</span>
+          <span className="mt-1 inline-flex items-center gap-1 rounded-full bg-gradient-to-r from-brand-600 to-violet-500 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-white shadow-brand">
+            <Sparkles size={10} strokeWidth={2.5} aria-hidden />
+            Appear soon
+          </span>
+        </span>
+      </span>
+    </span>
+  );
+}
 
 function Sidebar() {
   return (
@@ -36,7 +65,10 @@ function Sidebar() {
             <p className="px-3 pb-2 text-[11px] font-bold uppercase tracking-wider text-ink-400 dark:text-ink-500">
               {section.label}
             </p>
-            {section.items.map(({ to, label, icon, end }) => (
+            {section.items.map(({ to, label, icon, end, comingSoon }) =>
+              comingSoon ? (
+                <SidebarComingSoonItem key={to} label={label} icon={icon} />
+              ) : (
               <NavLink
                 key={to}
                 to={to}
@@ -74,7 +106,8 @@ function Sidebar() {
                   </>
                 )}
               </NavLink>
-            ))}
+              ),
+            )}
           </div>
         ))}
       </nav>

--- a/frontend/web/src/components/layout/Topbar.jsx
+++ b/frontend/web/src/components/layout/Topbar.jsx
@@ -3,6 +3,7 @@ import { Calendar } from "lucide-react";
 import NavbarActions from "../common/NavbarActions";
 import ThemeToggle from "../common/ThemeToggle";
 import Select from "../ui/Select";
+import { usePageFilters } from "../../context/usePageFilters";
 import { useTransactions } from "../../context/useTransactions";
 import { formatMonth } from "../../utils/format";
 
@@ -17,7 +18,8 @@ const TITLES = {
 
 function Topbar() {
   const { pathname } = useLocation();
-  const { months, filters, setFilters, ALL_MONTHS_SENTINEL } = useTransactions();
+  const { months, ALL_MONTHS_SENTINEL } = useTransactions();
+  const { filters, setFilters } = usePageFilters();
 
   const meta = TITLES[pathname] ?? TITLES["/"];
 

--- a/frontend/web/src/components/profile/ProfilePanel.jsx
+++ b/frontend/web/src/components/profile/ProfilePanel.jsx
@@ -147,7 +147,7 @@ function ProfilePanel({ onClose }) {
               </h3>
               <p className="mt-0.5 inline-flex items-center gap-1.5 rounded-full bg-brand-50 px-2 py-0.5 text-[11px] font-semibold text-brand-700 dark:bg-brand-900/30 dark:text-brand-200">
                 <span aria-hidden>{personality.emoji}</span>
-                {hasProfile ? personality.label : "Unlock AI coach"}
+                {hasProfile ? personality.label : "Profile not set up"}
               </p>
             </div>
           </div>
@@ -240,8 +240,8 @@ function ProfilePanel({ onClose }) {
         </div>
         <div className="mt-3 rounded-xl border border-brand-200 bg-brand-50/60 px-3 py-2 text-xs text-brand-800 dark:border-brand-800/60 dark:bg-brand-900/20 dark:text-brand-200">
           {hasProfile
-            ? "Advanced AI coach features are enabled for this profile."
-            : "Create your profile to enable AI coach and personalized recommendations."}
+            ? "Profile saved on this device. Export and personalization are available."
+            : "Create a profile to save your name and unlock export on this device."}
         </div>
       </section>
     </div>

--- a/frontend/web/src/components/profile/ProfilePanel.jsx
+++ b/frontend/web/src/components/profile/ProfilePanel.jsx
@@ -90,7 +90,7 @@ function exportCsv(rows) {
 }
 
 function ProfilePanel({ onClose }) {
-  const { transactions, replaceAll, setFilters, ALL_MONTHS_SENTINEL } = useTransactions();
+  const { transactions, replaceAll, resetAllPageFilters } = useTransactions();
   const { profile, cycleAvatar, updateProfile, hasProfile, displayName } = useProfile();
   const { theme, toggleTheme } = useTheme();
   const [nameInput, setNameInput] = useState(profile.name ?? "");
@@ -105,7 +105,7 @@ function ProfilePanel({ onClose }) {
 
   function handleReset() {
     replaceAll(seed);
-    setFilters((f) => ({ ...f, month: ALL_MONTHS_SENTINEL, categories: [], search: "" }));
+    resetAllPageFilters();
     onClose?.();
   }
 

--- a/frontend/web/src/context/TransactionsContext.jsx
+++ b/frontend/web/src/context/TransactionsContext.jsx
@@ -16,8 +16,14 @@ import {
 } from "../services/transactions";
 import { USE_MOCK } from "../api/client";
 import { ANALYSIS_SESSION_KEY } from "../constants/sessionAnalysis";
+import {
+  ALL_MONTHS_SENTINEL,
+  PAGE_KEYS,
+  applyFiltersToRows,
+  createInitialPageFilters,
+} from "./pageFilters.js";
 
-export const ALL_MONTHS_SENTINEL = "ALL";
+export { ALL_MONTHS_SENTINEL };
 // eslint-disable-next-line react-refresh/only-export-components
 export const TransactionsContext = createContext(null);
 
@@ -33,6 +39,15 @@ function readStoredAnalysis() {
   return null;
 }
 
+function buildDerived(filtered) {
+  return {
+    monthly: monthlyTotals(filtered),
+    monthlyByCategory: monthlyByCategory(filtered),
+    categories: categoryBreakdown(filtered),
+    merchants: merchantBreakdown(filtered),
+  };
+}
+
 export function TransactionsProvider({ children }) {
   const initialStored = readStoredAnalysis();
   const [transactions, setTransactions] = useState(() => {
@@ -40,13 +55,7 @@ export function TransactionsProvider({ children }) {
     return USE_MOCK ? seed : [];
   });
   const [restoredFromSession, setRestoredFromSession] = useState(Boolean(initialStored));
-  const [filters, setFilters] = useState({
-    month: ALL_MONTHS_SENTINEL,
-    categories: [],
-    search: "",
-    amountMin: null,
-    amountMax: null,
-  });
+  const [pageFilters, setPageFiltersState] = useState(createInitialPageFilters);
 
   useEffect(() => {
     let cancelled = false;
@@ -71,61 +80,33 @@ export function TransactionsProvider({ children }) {
     return Array.from(set).filter(Boolean).sort();
   }, [transactions]);
 
-  const applyFilters = useCallback(
-    (rows, { includeCategories = true } = {}) =>
-      rows.filter((t) => {
-        if (filters.month !== ALL_MONTHS_SENTINEL && monthKey(t.date) !== filters.month) {
-          return false;
-        }
-        if (
-          includeCategories &&
-          filters.categories.length &&
-          !filters.categories.includes(t.category)
-        ) {
-          return false;
-        }
-        if (filters.search) {
-          const q = filters.search.toLowerCase();
-          const hay = `${t.merchant_normalized ?? ""} ${t.merchant_raw ?? ""} ${t.description ?? ""}`.toLowerCase();
-          if (!hay.includes(q)) return false;
-        }
-        const amt = Math.abs(Number(t.amount ?? 0));
-        if (filters.amountMin != null && amt < filters.amountMin) return false;
-        if (filters.amountMax != null && amt > filters.amountMax) return false;
-        return true;
-      }),
-    [filters],
-  );
+  const setPageFilters = useCallback((pageKey, updater) => {
+    setPageFiltersState((prev) => {
+      const current = prev[pageKey];
+      const next = typeof updater === "function" ? updater(current) : updater;
+      return { ...prev, [pageKey]: next };
+    });
+  }, []);
 
-  const filtered = useMemo(
-    () => applyFilters(transactions),
-    [transactions, applyFilters],
-  );
+  const resetAllPageFilters = useCallback(() => {
+    setPageFiltersState(createInitialPageFilters());
+  }, []);
 
-  const scopeFiltered = useMemo(
-    () => applyFilters(transactions, { includeCategories: false }),
-    [transactions, applyFilters],
-  );
+  const filteredByPage = useMemo(() => {
+    const out = {};
+    for (const key of PAGE_KEYS) {
+      out[key] = applyFiltersToRows(transactions, pageFilters[key]);
+    }
+    return out;
+  }, [transactions, pageFilters]);
 
-  const derived = useMemo(
-    () => ({
-      monthly: monthlyTotals(filtered),
-      monthlyByCategory: monthlyByCategory(filtered),
-      categories: categoryBreakdown(filtered),
-      merchants: merchantBreakdown(filtered),
-    }),
-    [filtered],
-  );
-
-  const categoryDerived = useMemo(
-    () => ({
-      monthly: monthlyTotals(scopeFiltered),
-      monthlyByCategory: monthlyByCategory(scopeFiltered),
-      categories: categoryBreakdown(scopeFiltered),
-      merchants: merchantBreakdown(scopeFiltered),
-    }),
-    [scopeFiltered],
-  );
+  const derivedByPage = useMemo(() => {
+    const out = {};
+    for (const key of PAGE_KEYS) {
+      out[key] = buildDerived(filteredByPage[key]);
+    }
+    return out;
+  }, [filteredByPage]);
 
   const addMany = useCallback(async (rows) => {
     try {
@@ -146,14 +127,14 @@ export function TransactionsProvider({ children }) {
 
   const applyAnalysisResult = useCallback(async (analysis) => {
     if (!analysis || analysis.status !== "success" || !Array.isArray(analysis.transactions)) return;
-    
+
     setTransactions((prev) => {
       const isSeed = prev.length === seed.length && prev.every((t, i) => t.merchant_raw === seed[i].merchant_raw && t.amount === seed[i].amount);
       const baseList = isSeed ? [] : prev;
-      
+
       const seen = new Set();
       const merged = [];
-      
+
       for (const t of baseList) {
         const key = `${t.date}|${t.merchant_raw}|${t.amount}|${t.card_identity || ""}`;
         if (!seen.has(key)) {
@@ -161,7 +142,7 @@ export function TransactionsProvider({ children }) {
           merged.push(t);
         }
       }
-      
+
       for (const t of analysis.transactions) {
         const key = `${t.date}|${t.merchant_raw}|${t.amount}|${t.card_identity || ""}`;
         if (!seen.has(key)) {
@@ -169,24 +150,24 @@ export function TransactionsProvider({ children }) {
           merged.push(t);
         }
       }
-      
+
       let nextId = 1;
       const stamped = merged.map((t) => ({ ...t, id: nextId++ }));
-      
+
       if (USE_MOCK) {
         _replaceAllMock(stamped).catch(console.error);
       }
-      
+
       const updatedAnalysis = { ...analysis, transactions: stamped };
       try {
         sessionStorage.setItem(ANALYSIS_SESSION_KEY, JSON.stringify(updatedAnalysis));
       } catch {
         // ignore
       }
-      
+
       return stamped;
     });
-    
+
     setRestoredFromSession(false);
   }, []);
 
@@ -225,13 +206,12 @@ export function TransactionsProvider({ children }) {
   const value = {
     ALL_MONTHS_SENTINEL,
     transactions,
-    filtered,
-    scopeFiltered,
+    pageFilters,
+    setPageFilters,
+    resetAllPageFilters,
+    filteredByPage,
+    derivedByPage,
     months,
-    filters,
-    setFilters,
-    derived,
-    categoryDerived,
     addMany,
     replaceAll,
     updateCategory,

--- a/frontend/web/src/context/TransactionsContext.jsx
+++ b/frontend/web/src/context/TransactionsContext.jsx
@@ -71,25 +71,41 @@ export function TransactionsProvider({ children }) {
     return Array.from(set).filter(Boolean).sort();
   }, [transactions]);
 
-  const filtered = useMemo(() => {
-    return transactions.filter((t) => {
-      if (filters.month !== ALL_MONTHS_SENTINEL && monthKey(t.date) !== filters.month) {
-        return false;
-      }
-      if (filters.categories.length && !filters.categories.includes(t.category)) {
-        return false;
-      }
-      if (filters.search) {
-        const q = filters.search.toLowerCase();
-        const hay = `${t.merchant_normalized ?? ""} ${t.merchant_raw ?? ""} ${t.description ?? ""}`.toLowerCase();
-        if (!hay.includes(q)) return false;
-      }
-      const amt = Math.abs(Number(t.amount ?? 0));
-      if (filters.amountMin != null && amt < filters.amountMin) return false;
-      if (filters.amountMax != null && amt > filters.amountMax) return false;
-      return true;
-    });
-  }, [transactions, filters]);
+  const applyFilters = useCallback(
+    (rows, { includeCategories = true } = {}) =>
+      rows.filter((t) => {
+        if (filters.month !== ALL_MONTHS_SENTINEL && monthKey(t.date) !== filters.month) {
+          return false;
+        }
+        if (
+          includeCategories &&
+          filters.categories.length &&
+          !filters.categories.includes(t.category)
+        ) {
+          return false;
+        }
+        if (filters.search) {
+          const q = filters.search.toLowerCase();
+          const hay = `${t.merchant_normalized ?? ""} ${t.merchant_raw ?? ""} ${t.description ?? ""}`.toLowerCase();
+          if (!hay.includes(q)) return false;
+        }
+        const amt = Math.abs(Number(t.amount ?? 0));
+        if (filters.amountMin != null && amt < filters.amountMin) return false;
+        if (filters.amountMax != null && amt > filters.amountMax) return false;
+        return true;
+      }),
+    [filters],
+  );
+
+  const filtered = useMemo(
+    () => applyFilters(transactions),
+    [transactions, applyFilters],
+  );
+
+  const scopeFiltered = useMemo(
+    () => applyFilters(transactions, { includeCategories: false }),
+    [transactions, applyFilters],
+  );
 
   const derived = useMemo(
     () => ({
@@ -99,6 +115,16 @@ export function TransactionsProvider({ children }) {
       merchants: merchantBreakdown(filtered),
     }),
     [filtered],
+  );
+
+  const categoryDerived = useMemo(
+    () => ({
+      monthly: monthlyTotals(scopeFiltered),
+      monthlyByCategory: monthlyByCategory(scopeFiltered),
+      categories: categoryBreakdown(scopeFiltered),
+      merchants: merchantBreakdown(scopeFiltered),
+    }),
+    [scopeFiltered],
   );
 
   const addMany = useCallback(async (rows) => {
@@ -200,10 +226,12 @@ export function TransactionsProvider({ children }) {
     ALL_MONTHS_SENTINEL,
     transactions,
     filtered,
+    scopeFiltered,
     months,
     filters,
     setFilters,
     derived,
+    categoryDerived,
     addMany,
     replaceAll,
     updateCategory,

--- a/frontend/web/src/context/pageFilters.js
+++ b/frontend/web/src/context/pageFilters.js
@@ -1,0 +1,50 @@
+import { monthKey } from "../utils/format";
+
+export const ALL_MONTHS_SENTINEL = "ALL";
+
+export const PAGE_KEYS = ["overview", "transactions", "categories", "insights"];
+
+export function createDefaultPageFilters() {
+  return {
+    month: ALL_MONTHS_SENTINEL,
+    categories: [],
+    search: "",
+    amountMin: null,
+    amountMax: null,
+  };
+}
+
+export function createInitialPageFilters() {
+  return Object.fromEntries(PAGE_KEYS.map((key) => [key, createDefaultPageFilters()]));
+}
+
+export function pathnameToPageKey(pathname) {
+  if (pathname === "/transactions") return "transactions";
+  if (pathname.startsWith("/categories")) return "categories";
+  if (pathname === "/insights") return "insights";
+  return "overview";
+}
+
+export function applyFiltersToRows(rows, filters, { includeCategories = true } = {}) {
+  return rows.filter((t) => {
+    if (filters.month !== ALL_MONTHS_SENTINEL && monthKey(t.date) !== filters.month) {
+      return false;
+    }
+    if (
+      includeCategories &&
+      filters.categories.length &&
+      !filters.categories.includes(t.category)
+    ) {
+      return false;
+    }
+    if (filters.search) {
+      const q = filters.search.toLowerCase();
+      const hay = `${t.merchant_normalized ?? ""} ${t.merchant_raw ?? ""} ${t.description ?? ""}`.toLowerCase();
+      if (!hay.includes(q)) return false;
+    }
+    const amt = Math.abs(Number(t.amount ?? 0));
+    if (filters.amountMin != null && amt < filters.amountMin) return false;
+    if (filters.amountMax != null && amt > filters.amountMax) return false;
+    return true;
+  });
+}

--- a/frontend/web/src/context/usePageFilters.js
+++ b/frontend/web/src/context/usePageFilters.js
@@ -1,0 +1,17 @@
+import { useLocation } from "react-router-dom";
+import { useTransactions } from "./useTransactions";
+import { pathnameToPageKey } from "./pageFilters";
+
+export function usePageFilters(explicitPageKey) {
+  const { pathname } = useLocation();
+  const pageKey = explicitPageKey ?? pathnameToPageKey(pathname);
+  const { pageFilters, setPageFilters, filteredByPage, derivedByPage } = useTransactions();
+
+  return {
+    pageKey,
+    filters: pageFilters[pageKey],
+    setFilters: (updater) => setPageFilters(pageKey, updater),
+    filtered: filteredByPage[pageKey],
+    derived: derivedByPage[pageKey],
+  };
+}

--- a/frontend/web/src/pages/CategoriesPage.jsx
+++ b/frontend/web/src/pages/CategoriesPage.jsx
@@ -11,19 +11,19 @@ import EmptyState from "../components/ui/EmptyState";
 import SectionHeader from "../components/ui/SectionHeader";
 import MiniSparkline from "../components/charts/MiniSparkline";
 import MonthlyCategoryBars from "../components/charts/MonthlyCategoryBars";
-import { useTransactions } from "../context/useTransactions";
+import { usePageFilters } from "../context/usePageFilters";
 import useDocumentTitle from "../hooks/useDocumentTitle";
 import { categoryColor } from "../utils/categories";
 import { formatAmountSpend, formatCurrency, formatDate } from "../utils/format";
 
 function CategoryGrid() {
-  const { scopeFiltered, categoryDerived } = useTransactions();
-  const total = categoryDerived.categories.reduce((s, c) => s + c.total, 0);
+  const { derived } = usePageFilters("categories");
+  const total = derived.categories.reduce((s, c) => s + c.total, 0);
 
   // Sparkline points per category (across months in current filter)
   const sparkByCat = useMemo(() => {
     const out = {};
-    for (const m of categoryDerived.monthlyByCategory) {
+    for (const m of derived.monthlyByCategory) {
       for (const k of Object.keys(m)) {
         if (k === "month") continue;
         out[k] = out[k] ?? [];
@@ -31,9 +31,9 @@ function CategoryGrid() {
       }
     }
     return out;
-  }, [categoryDerived.monthlyByCategory]);
+  }, [derived.monthlyByCategory]);
 
-  if (categoryDerived.categories.length === 0) {
+  if (derived.categories.length === 0) {
     return (
       <Card>
         <EmptyState
@@ -47,7 +47,7 @@ function CategoryGrid() {
 
   return (
     <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
-      {categoryDerived.categories.map((c) => {
+      {derived.categories.map((c) => {
         const share = total ? (c.total / total) * 100 : 0;
         const color = categoryColor(c.category);
         return (
@@ -80,18 +80,18 @@ function CategoryGrid() {
 }
 
 function CategoryDetail({ name }) {
-  const { scopeFiltered, categoryDerived } = useTransactions();
+  const { filtered, derived } = usePageFilters("categories");
 
   const monthlyForCat = useMemo(() => {
-    return categoryDerived.monthlyByCategory.map((m) => ({ month: m.month, total: m[name] ?? 0 }));
-  }, [categoryDerived.monthlyByCategory, name]);
+    return derived.monthlyByCategory.map((m) => ({ month: m.month, total: m[name] ?? 0 }));
+  }, [derived.monthlyByCategory, name]);
 
   const txns = useMemo(
     () =>
-      [...scopeFiltered]
+      [...filtered]
         .filter((t) => t.category === name)
         .sort((a, b) => (a.date < b.date ? 1 : -1)),
-    [scopeFiltered, name],
+    [filtered, name],
   );
 
   const total = txns.reduce((s, t) => s + Math.abs(t.amount), 0);
@@ -209,7 +209,6 @@ function CategoriesPage() {
         <SectionHeader
           eyebrow="Categories"
           title="How your money is split"
-          action={<Pill tone="dark">All categories</Pill>}
         />
       </Card>
       <CategoryGrid />

--- a/frontend/web/src/pages/CategoriesPage.jsx
+++ b/frontend/web/src/pages/CategoriesPage.jsx
@@ -17,13 +17,13 @@ import { categoryColor } from "../utils/categories";
 import { formatAmountSpend, formatCurrency, formatDate } from "../utils/format";
 
 function CategoryGrid() {
-  const { filtered, derived } = useTransactions();
-  const total = derived.categories.reduce((s, c) => s + c.total, 0);
+  const { scopeFiltered, categoryDerived } = useTransactions();
+  const total = categoryDerived.categories.reduce((s, c) => s + c.total, 0);
 
   // Sparkline points per category (across months in current filter)
   const sparkByCat = useMemo(() => {
     const out = {};
-    for (const m of derived.monthlyByCategory) {
+    for (const m of categoryDerived.monthlyByCategory) {
       for (const k of Object.keys(m)) {
         if (k === "month") continue;
         out[k] = out[k] ?? [];
@@ -31,9 +31,9 @@ function CategoryGrid() {
       }
     }
     return out;
-  }, [derived.monthlyByCategory]);
+  }, [categoryDerived.monthlyByCategory]);
 
-  if (derived.categories.length === 0) {
+  if (categoryDerived.categories.length === 0) {
     return (
       <Card>
         <EmptyState
@@ -47,7 +47,7 @@ function CategoryGrid() {
 
   return (
     <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
-      {derived.categories.map((c) => {
+      {categoryDerived.categories.map((c) => {
         const share = total ? (c.total / total) * 100 : 0;
         const color = categoryColor(c.category);
         return (
@@ -63,8 +63,7 @@ function CategoryGrid() {
                     {formatCurrency(c.total)}
                   </p>
                   <p className="mt-1 text-xs font-semibold text-ink-500 dark:text-ink-400">
-                    {share.toFixed(1)}% of spend · {c.count} txns ·{" "}
-                    {filtered.filter((t) => t.category === c.category).length} in view
+                    {share.toFixed(1)}% of spend · {c.count} txns
                   </p>
                 </div>
                 <Badge tone="neutral">View</Badge>
@@ -81,18 +80,18 @@ function CategoryGrid() {
 }
 
 function CategoryDetail({ name }) {
-  const { filtered, derived } = useTransactions();
+  const { scopeFiltered, categoryDerived } = useTransactions();
 
   const monthlyForCat = useMemo(() => {
-    return derived.monthlyByCategory.map((m) => ({ month: m.month, total: m[name] ?? 0 }));
-  }, [derived.monthlyByCategory, name]);
+    return categoryDerived.monthlyByCategory.map((m) => ({ month: m.month, total: m[name] ?? 0 }));
+  }, [categoryDerived.monthlyByCategory, name]);
 
   const txns = useMemo(
     () =>
-      [...filtered]
+      [...scopeFiltered]
         .filter((t) => t.category === name)
         .sort((a, b) => (a.date < b.date ? 1 : -1)),
-    [filtered, name],
+    [scopeFiltered, name],
   );
 
   const total = txns.reduce((s, t) => s + Math.abs(t.amount), 0);

--- a/frontend/web/src/pages/InsightsPage.jsx
+++ b/frontend/web/src/pages/InsightsPage.jsx
@@ -2,12 +2,12 @@ import { createElement } from "react";
 import {
   Activity,
   AlertTriangle,
-  Bot,
   CalendarClock,
   Lock,
   Repeat,
   TrendingDown,
   TrendingUp,
+  UserCircle,
 } from "lucide-react";
 import Card from "../components/ui/Card";
 import Badge from "../components/ui/Badge";
@@ -86,7 +86,7 @@ function InsightsPage() {
       <Card variant="dark">
         <div className="flex items-center justify-between gap-4">
           <div>
-            <p className="text-sm text-ink-300">Insight Engine</p>
+            <p className="text-sm text-ink-300">Spending summary</p>
             <h2 className="mt-2 text-2xl font-black md:text-3xl">
               {isAllMonths
                 ? "All months in view"
@@ -241,20 +241,20 @@ function InsightsPage() {
         />
 
         <NarrativeCard
-          icon={Bot}
-          eyebrow="AI coach"
-          title={hasProfile ? "Personalized recommendations" : "Profile required"}
+          icon={UserCircle}
+          eyebrow="Profile"
+          title={hasProfile ? "Saved on this device" : "Profile required"}
           tone={hasProfile ? "success" : "neutral"}
           body={
             hasProfile
-              ? "Your profile is active. AI spend coach can now use your behavior patterns to suggest smarter monthly optimizations."
-              : "You are in guest mode. Create a profile from the top-right profile tab to unlock AI coach, custom goals, and proactive savings suggestions."
+              ? "Your name and preferences are stored locally in this browser."
+              : "Guest mode works for browsing. Create a profile from the top-right tab to save your name and export data."
           }
         >
           <div className="mt-4 rounded-xl2 bg-[#f8fbff] px-4 py-3 dark:bg-ink-800/60">
             {hasProfile ? (
               <p className="text-sm font-semibold text-emerald-700 dark:text-emerald-300">
-                AI coach status: ready
+                Profile active
               </p>
             ) : (
               <p className="inline-flex items-center gap-2 text-sm font-semibold text-ink-600 dark:text-ink-300">

--- a/frontend/web/src/pages/InsightsPage.jsx
+++ b/frontend/web/src/pages/InsightsPage.jsx
@@ -13,17 +13,20 @@ import Card from "../components/ui/Card";
 import Badge from "../components/ui/Badge";
 import CategoryDot from "../components/ui/CategoryDot";
 import SectionHeader from "../components/ui/SectionHeader";
+import { usePageFilters } from "../context/usePageFilters";
 import { useTransactions } from "../context/useTransactions";
+import { ALL_MONTHS_SENTINEL } from "../context/pageFilters";
 import useDocumentTitle from "../hooks/useDocumentTitle";
 import { useProfile } from "../hooks/useProfile";
 import {
-  compareMonthOverMonth,
+  compareSelectedMonthToPrevious,
   detectRecurring,
+  previousMonthKey,
   topAnomalies,
-  topCategoryMovers,
+  topCategoryMoversForMonth,
   weekdayVsWeekend,
 } from "../utils/insights";
-import { formatAmountSpend, formatCurrency, formatDate, formatPct } from "../utils/format";
+import { formatAmountSpend, formatCurrency, formatDate, formatMonth, formatPct } from "../utils/format";
 
 function NarrativeCard({ icon, eyebrow, title, body, tone = "neutral", children }) {
   const tones = {
@@ -55,22 +58,28 @@ function NarrativeCard({ icon, eyebrow, title, body, tone = "neutral", children 
 
 function InsightsPage() {
   useDocumentTitle("Insights");
-  const { filtered } = useTransactions();
+  const { transactions } = useTransactions();
+  const { filtered, filters } = usePageFilters("insights");
   const { hasProfile } = useProfile();
 
-  const mom = compareMonthOverMonth(filtered);
-  const movers = topCategoryMovers(filtered);
+  const isAllMonths = filters.month === ALL_MONTHS_SENTINEL;
+  const mom = isAllMonths
+    ? { deltaPct: null, deltaAbs: 0, current: null, previous: null }
+    : compareSelectedMonthToPrevious(transactions, filters.month);
+  const movers = isAllMonths ? [] : topCategoryMoversForMonth(transactions, filters.month);
   const recurring = detectRecurring(filtered);
   const anomalies = topAnomalies(filtered, 5);
   const week = weekdayVsWeekend(filtered);
+  const priorMonthLabel = isAllMonths ? "" : formatMonth(previousMonthKey(filters.month));
 
   const annualizedRecurring = recurring.reduce((s, r) => s + r.annualized, 0);
-  const momCopy =
-    mom.deltaPct == null
-      ? "Need at least 2 months to compare."
+  const momCopy = isAllMonths
+    ? "Select a month in the header to compare spending vs the prior month."
+    : mom.deltaPct == null
+      ? `No data for the month before ${formatMonth(filters.month)}.`
       : `You spent ${formatCurrency(Math.abs(mom.deltaAbs))} ${
           mom.deltaAbs >= 0 ? "more" : "less"
-        } this month than last (${formatPct(mom.deltaPct)}).`;
+        } in ${formatMonth(filters.month)} than ${priorMonthLabel} (${formatPct(mom.deltaPct)}).`;
 
   return (
     <section className="space-y-5 pt-2">
@@ -79,11 +88,13 @@ function InsightsPage() {
           <div>
             <p className="text-sm text-ink-300">Insight Engine</p>
             <h2 className="mt-2 text-2xl font-black md:text-3xl">
-              {mom.deltaPct == null
-                ? "Build a baseline"
-                : mom.deltaAbs >= 0
-                  ? `Spend up ${formatPct(mom.deltaPct)} this month`
-                  : `Spend down ${formatPct(mom.deltaPct)} this month`}
+              {isAllMonths
+                ? "All months in view"
+                : mom.deltaPct == null
+                  ? "Build a baseline"
+                  : mom.deltaAbs >= 0
+                    ? `Spend up ${formatPct(mom.deltaPct)} in ${formatMonth(filters.month)}`
+                    : `Spend down ${formatPct(mom.deltaPct)} in ${formatMonth(filters.month)}`}
             </h2>
             <p className="mt-2 text-ink-300 max-w-2xl">{momCopy}</p>
           </div>
@@ -99,9 +110,13 @@ function InsightsPage() {
         <NarrativeCard
           icon={Activity}
           eyebrow="Movers"
-          title="Biggest swings"
+          title={isAllMonths ? "Month-over-month" : "Biggest swings"}
           tone={movers[0]?.deltaAbs > 0 ? "danger" : "success"}
-          body="Categories that moved most vs the previous month."
+          body={
+            isAllMonths
+              ? "Pick a month above to see which categories moved most vs the prior month."
+              : `Categories that moved most in ${formatMonth(filters.month)} vs ${priorMonthLabel}.`
+          }
         >
           <div className="mt-4 space-y-3">
             {movers.length === 0 ? (

--- a/frontend/web/src/pages/OverviewPage.jsx
+++ b/frontend/web/src/pages/OverviewPage.jsx
@@ -21,16 +21,19 @@ import CategoryDonut from "../components/charts/CategoryDonut";
 import WelcomeHero from "../components/dashboard/WelcomeHero";
 import Reveal from "../components/effects/Reveal";
 import { StaggerGroup, StaggerItem } from "../components/effects/StaggerGroup";
+import { usePageFilters } from "../context/usePageFilters";
 import { useTransactions } from "../context/useTransactions";
+import { ALL_MONTHS_SENTINEL } from "../context/pageFilters";
 import useDocumentTitle from "../hooks/useDocumentTitle";
 import {
-  compareMonthOverMonth,
+  compareSelectedMonthToPrevious,
   dailyAverage,
   detectRecurring,
-  topCategoryMovers,
+  previousMonthKey,
+  topCategoryMoversForMonth,
   totalSpend,
 } from "../utils/insights";
-import { formatAmountSpend, formatCurrency, formatDate, formatPct } from "../utils/format";
+import { formatAmountSpend, formatCurrency, formatDate, formatMonth, formatPct } from "../utils/format";
 
 function TopMerchantsList({ merchants }) {
   if (!merchants.length) {
@@ -90,19 +93,24 @@ function RecentTxStrip({ rows }) {
 
 function OverviewPage() {
   useDocumentTitle("Overview");
-  const { filtered, derived } = useTransactions();
+  const { transactions } = useTransactions();
+  const { filtered, derived, filters } = usePageFilters("overview");
   const [activeCatIdx, setActiveCatIdx] = useState(null);
 
+  const isAllMonths = filters.month === ALL_MONTHS_SENTINEL;
   const total = totalSpend(filtered);
-  const mom = compareMonthOverMonth(filtered);
+  const mom = isAllMonths
+    ? { deltaPct: null, deltaAbs: 0, current: null, previous: null }
+    : compareSelectedMonthToPrevious(transactions, filters.month);
   const avgDaily = dailyAverage(filtered);
-  const movers = topCategoryMovers(filtered);
+  const movers = isAllMonths ? [] : topCategoryMoversForMonth(transactions, filters.month);
   const recurring = detectRecurring(filtered);
   const topCategory = derived.categories[0];
   const annualizedRecurring = recurring.reduce((s, r) => s + r.annualized, 0);
   const recentTx = [...filtered]
     .sort((a, b) => (b.date < a.date ? -1 : 1))
     .slice(0, 5);
+  const priorMonthLabel = isAllMonths ? "" : formatMonth(previousMonthKey(filters.month));
 
   const thisWeek = useMemo(() => {
     const now = new Date();
@@ -121,10 +129,11 @@ function OverviewPage() {
   }, [filtered]);
 
   const momTone = mom.deltaPct == null ? "neutral" : mom.deltaPct < 0 ? "up" : "down";
-  const momLabel =
-    mom.deltaPct == null
-      ? "First period"
-      : `${formatPct(mom.deltaPct)} vs last month`;
+  const momLabel = isAllMonths
+    ? `Across ${derived.monthly.length || 0} months`
+    : mom.deltaPct == null
+      ? "No prior month to compare"
+      : `${formatPct(mom.deltaPct)} vs ${priorMonthLabel}`;
 
   return (
     <section className="space-y-5 pt-2">
@@ -193,11 +202,15 @@ function OverviewPage() {
             </div>
           </Card>
 
-          {/* Movers */}
+          {/* Movers / top categories */}
           <Card>
             <SectionHeader
-              eyebrow="What changed"
-              title="Biggest category movers vs last month"
+              eyebrow={isAllMonths ? "All time" : "What changed"}
+              title={
+                isAllMonths
+                  ? "Top spending categories"
+                  : `Biggest movers vs ${priorMonthLabel}`
+              }
               action={
                 <Link to="/insights">
                   <IconButton variant="dark" aria-label="See all insights">
@@ -207,8 +220,42 @@ function OverviewPage() {
               }
             />
             <div className="mt-6 grid gap-3 md:grid-cols-2">
-              {movers.length === 0 ? (
-                <p className="text-sm text-ink-500 dark:text-ink-400">Need at least 2 months of data to compare.</p>
+              {isAllMonths ? (
+                derived.categories.length === 0 ? (
+                  <p className="text-sm text-ink-500 dark:text-ink-400">No category activity yet.</p>
+                ) : (
+                  derived.categories.slice(0, 4).map((c) => {
+                    const share = total ? (c.total / total) * 100 : 0;
+                    return (
+                      <div
+                        key={c.category}
+                        className="flex items-center justify-between rounded-xl2 bg-[#f8fbff] px-4 py-3 dark:bg-ink-800/60"
+                      >
+                        <div className="flex items-center gap-3 min-w-0">
+                          <CategoryDot category={c.category} size={10} />
+                          <div className="min-w-0">
+                            <p className="truncate font-bold text-ink-900 dark:text-ink-50">{c.category}</p>
+                            <p className="text-xs text-ink-500 dark:text-ink-400">
+                              {c.count} {c.count === 1 ? "transaction" : "transactions"}
+                            </p>
+                          </div>
+                        </div>
+                        <div className="shrink-0 text-right">
+                          <p className="tabular font-black text-ink-900 dark:text-ink-50">
+                            {formatCurrency(c.total)}
+                          </p>
+                          <p className="text-xs font-semibold text-ink-500 dark:text-ink-400">
+                            {share.toFixed(1)}% of spend
+                          </p>
+                        </div>
+                      </div>
+                    );
+                  })
+                )
+              ) : movers.length === 0 ? (
+                <p className="text-sm text-ink-500 dark:text-ink-400">
+                  No prior month data for {formatMonth(filters.month)}.
+                </p>
               ) : (
                 movers.slice(0, 4).map((m) => {
                   const up = m.deltaAbs >= 0;
@@ -372,11 +419,17 @@ function OverviewPage() {
             <TrendingUp className="text-emerald-400" />
           </div>
           <p className="mt-5 text-ink-300">
-            {movers.length > 0 && movers[0].deltaAbs > 0
-              ? `${movers[0].category} spend rose ${formatPct(movers[0].deltaPct)} (${formatCurrency(
-                  Math.abs(movers[0].deltaAbs),
-                )}) compared to last month — the biggest jump in your portfolio.`
-              : "Your spend looks steady this month. Use the Insights tab for deeper breakdowns."}
+            {isAllMonths
+              ? topCategory
+                ? `${topCategory.category} is your largest category at ${formatCurrency(topCategory.total)} across all months. Pick a month above to see month-over-month changes.`
+                : "Upload transactions to unlock spending insights."
+              : movers.length > 0 && movers[0].deltaAbs > 0
+                ? `${movers[0].category} spend rose ${formatPct(movers[0].deltaPct)} (${formatCurrency(
+                    Math.abs(movers[0].deltaAbs),
+                  )}) vs ${priorMonthLabel} — the biggest jump in that period.`
+                : movers.length > 0
+                  ? "Your category mix looks steady compared to the prior month."
+                  : "Select a month with prior data to see how spending shifted."}
           </p>
           <div className="mt-6 grid gap-3 md:grid-cols-2">
             <div className="rounded-xl2 bg-white/10 px-4 py-4">

--- a/frontend/web/src/pages/OverviewPage.jsx
+++ b/frontend/web/src/pages/OverviewPage.jsx
@@ -409,12 +409,12 @@ function OverviewPage() {
       </Reveal>
 
       <Reveal delay={0.05}>
-        {/* Insight engine */}
+        {/* Spending highlights */}
         <Card variant="dark">
           <div className="flex items-start justify-between gap-4">
             <div>
-              <p className="text-sm text-ink-300">Insight Engine</p>
-              <h3 className="mt-2 text-2xl font-black">Smart observation</h3>
+              <p className="text-sm text-ink-300">Highlights</p>
+              <h3 className="mt-2 text-2xl font-black">At a glance</h3>
             </div>
             <TrendingUp className="text-emerald-400" />
           </div>
@@ -433,9 +433,13 @@ function OverviewPage() {
           </p>
           <div className="mt-6 grid gap-3 md:grid-cols-2">
             <div className="rounded-xl2 bg-white/10 px-4 py-4">
-              <p className="text-sm text-ink-300">Suggested action</p>
+              <p className="text-sm text-ink-300">Worth a look</p>
               <p className="mt-1 font-semibold text-white">
-                Cap dining spend for the next 2 weeks and review recurring charges.
+                {recurring.length > 0
+                  ? `You have ${recurring.length} recurring charge${recurring.length === 1 ? "" : "s"} (~${formatCurrency(annualizedRecurring, { compact: true })}/yr).`
+                  : topCategory
+                    ? `${topCategory.category} leads your spending at ${formatCurrency(topCategory.total, { compact: true })}.`
+                    : "Import transactions to see where your money goes."}
               </p>
             </div>
             <Link to="/insights" className="block">

--- a/frontend/web/src/pages/TransactionsPage.jsx
+++ b/frontend/web/src/pages/TransactionsPage.jsx
@@ -10,6 +10,7 @@ import CategoryDot from "../components/ui/CategoryDot";
 import EmptyState from "../components/ui/EmptyState";
 import Drawer from "../components/ui/Drawer";
 import Button from "../components/ui/Button";
+import { usePageFilters } from "../context/usePageFilters";
 import { useTransactions } from "../context/useTransactions";
 import useDocumentTitle from "../hooks/useDocumentTitle";
 import { CATEGORIES } from "../utils/categories";
@@ -92,7 +93,8 @@ function CategoryChip({ active, label, onToggle }) {
 
 function TransactionsPage() {
   useDocumentTitle("Transactions");
-  const { filtered, filters, setFilters, updateCategory } = useTransactions();
+  const { filtered, filters, setFilters } = usePageFilters("transactions");
+  const { updateCategory } = useTransactions();
   const [openTx, setOpenTx] = useState(null);
 
   const sorted = useMemo(

--- a/frontend/web/src/types/README.md
+++ b/frontend/web/src/types/README.md
@@ -26,7 +26,7 @@ Source of truth for the data shapes the web frontend expects from / sends to the
 - All dates are ISO-8601 (`YYYY-MM-DD` for calendar dates, RFC 3339 for instants).
 - Pagination is not yet defined; v1 returns full result sets capped at 5,000 rows.
 - The frontend treats `Filters.month === "ALL"` as "no month filter".
-- The product is guest-accessible without authentication. Advanced features (AI coach, personalized recommendations) are unlocked only when `Profile.profileCompleted === true`.
+- The product is guest-accessible without authentication. A completed profile (`Profile.profileCompleted === true`) saves your name locally and enables export.
 
 ## How to validate
 

--- a/frontend/web/src/utils/insights.js
+++ b/frontend/web/src/utils/insights.js
@@ -76,24 +76,56 @@ export function compareMonthOverMonth(transactions) {
   return { current, previous, deltaPct, deltaAbs };
 }
 
-export function topCategoryMovers(transactions) {
-  // Compare last full month to one before, return categories with the biggest swings.
-  const months = monthlyByCategory(transactions);
-  if (months.length < 2) return [];
-  const [prev, cur] = months.slice(-2);
+export function previousMonthKey(key) {
+  const [y, m] = key.split("-").map(Number);
+  const d = new Date(y, m - 1, 1);
+  d.setMonth(d.getMonth() - 1);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+}
+
+export function compareSelectedMonthToPrevious(transactions, selectedMonth) {
+  const totals = monthlyTotals(transactions);
+  const current = totals.find((t) => t.month === selectedMonth) ?? null;
+  const previous = totals.find((t) => t.month === previousMonthKey(selectedMonth)) ?? null;
+  if (!current || !previous) {
+    return { current, previous, deltaPct: null, deltaAbs: 0 };
+  }
+  const deltaAbs = current.total - previous.total;
+  const deltaPct = previous.total > 0 ? (deltaAbs / previous.total) * 100 : null;
+  return { current, previous, deltaPct, deltaAbs };
+}
+
+function categoryMoversBetween(prevRow, curRow) {
+  if (!prevRow || !curRow) return [];
   const cats = new Set([
-    ...Object.keys(prev).filter((k) => k !== "month"),
-    ...Object.keys(cur).filter((k) => k !== "month"),
+    ...Object.keys(prevRow).filter((k) => k !== "month"),
+    ...Object.keys(curRow).filter((k) => k !== "month"),
   ]);
   const movers = [];
   for (const c of cats) {
-    const a = prev[c] ?? 0;
-    const b = cur[c] ?? 0;
+    const a = prevRow[c] ?? 0;
+    const b = curRow[c] ?? 0;
     const deltaAbs = b - a;
     const deltaPct = a > 0 ? (deltaAbs / a) * 100 : b > 0 ? 100 : 0;
     movers.push({ category: c, prev: a, current: b, deltaAbs, deltaPct });
   }
   return movers.sort((a, b) => Math.abs(b.deltaAbs) - Math.abs(a.deltaAbs));
+}
+
+export function topCategoryMovers(transactions) {
+  // Compare last full month to one before, return categories with the biggest swings.
+  const months = monthlyByCategory(transactions);
+  if (months.length < 2) return [];
+  const [prev, cur] = months.slice(-2);
+  return categoryMoversBetween(prev, cur);
+}
+
+export function topCategoryMoversForMonth(transactions, selectedMonth) {
+  const months = monthlyByCategory(transactions);
+  const prevKey = previousMonthKey(selectedMonth);
+  const prev = months.find((m) => m.month === prevKey);
+  const cur = months.find((m) => m.month === selectedMonth);
+  return categoryMoversBetween(prev, cur);
 }
 
 export function detectRecurring(transactions) {


### PR DESCRIPTION
## Summary
- Disable House Sale in sidebar/mobile nav with an appear-soon teaser while keeping the route intact for later launch
- Scope filters per tab so transaction category chips no longer leak into Overview, Categories, or Insights
- Fix Categories and Overview month-over-month logic: all-months view shows all-time category totals; single-month view compares against the prior month
- Enable local CSV upload by adding CORS to the dev API and documenting local env setup
- Remove the non-functional "All categories" pill from the Categories header

## Test plan
- [ ] Open Overview with All months — confirm full category breakdown and no misleading "vs last month" movers
- [ ] Filter Groceries on Transactions, then visit Categories and Overview — confirm Groceries filter stays on Transactions only
- [ ] Select a single month on Overview — confirm MoM KPI and movers compare to the prior month
- [ ] Confirm House Sale nav item is visible but not clickable; route still works via direct URL if needed
- [ ] Run backend and frontend locally with `VITE_USE_MOCK=false` — upload a CSV on the Import page and confirm analysis succeeds
- [ ] Check mobile nav House Sale appear-soon state