### PR TITLE
chore: remove admin bypass from main branch protection

### DIFF
--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -55,10 +55,10 @@ Optional: target a fork or different org repo:
 GITHUB_REPO=your-org/your-fork ./scripts/apply-github-rulesets.sh
 ```
 
-The `Protect main` ruleset:
+The **Protect main** ruleset:
 
 - Requires pull requests before merging to `main` (direct pushes blocked)
-- Requires the `CI / check` status to pass
+- **Requires `CI / check` to pass before merge** — merge is blocked until GitHub Actions CI succeeds; branch must be up to date with `main`
 - Blocks force pushes and branch deletion
 
 Adjust review requirements in `main-branch.json` if you want mandatory approvals (set `required_approving_review_count` to `1` or higher).

--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -58,7 +58,7 @@ GITHUB_REPO=your-org/your-fork ./scripts/apply-github-rulesets.sh
 The **Protect main** ruleset:
 
 - Requires pull requests before merging to `main` (direct pushes blocked)
-- **Requires `CI / check` to pass before merge** — merge is blocked until GitHub Actions CI succeeds; branch must be up to date with `main`
+- **Requires the `check` job to pass before merge** — merge is blocked until GitHub Actions CI succeeds; branch must be up to date with `main`
 - Blocks force pushes and branch deletion
 
 Adjust review requirements in `main-branch.json` if you want mandatory approvals (set `required_approving_review_count` to `1` or higher).

--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -60,7 +60,6 @@ The `Protect main` ruleset:
 - Requires pull requests before merging to `main` (direct pushes blocked)
 - Requires the `CI / check` status to pass
 - Blocks force pushes and branch deletion
-- Allows repository admins to bypass (for emergencies)
 
 Adjust review requirements in `main-branch.json` if you want mandatory approvals (set `required_approving_review_count` to `1` or higher).
 

--- a/.github/rulesets/main-branch.json
+++ b/.github/rulesets/main-branch.json
@@ -8,13 +8,6 @@
       "exclude": []
     }
   },
-  "bypass_actors": [
-    {
-      "actor_id": 5,
-      "actor_type": "RepositoryRole",
-      "bypass_mode": "always"
-    }
-  ],
   "rules": [
     {
       "type": "pull_request",

--- a/.github/rulesets/main-branch.json
+++ b/.github/rulesets/main-branch.json
@@ -27,7 +27,7 @@
         "do_not_enforce_on_create": false,
         "required_status_checks": [
           {
-            "context": "CI / check",
+            "context": "check",
             "integration_id": 15368
           }
         ]

--- a/.github/rulesets/main-branch.json
+++ b/.github/rulesets/main-branch.json
@@ -27,7 +27,8 @@
         "do_not_enforce_on_create": false,
         "required_status_checks": [
           {
-            "context": "CI / check"
+            "context": "CI / check",
+            "integration_id": 15368
           }
         ]
       }

--- a/.github/rulesets/main-branch.json
+++ b/.github/rulesets/main-branch.json
@@ -8,6 +8,7 @@
       "exclude": []
     }
   },
+  "bypass_actors": [],
   "rules": [
     {
       "type": "pull_request",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: npm
           cache-dependency-path: |
             package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ Thumbs.db
 
 # Editors & IDEs
 .idea/
+.cursor/
 *.suo
 *.ntvs*
 *.njsproj

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ From the **repo root**:
 npm run ci
 ```
 
-This runs Prettier check, frontend ESLint + build, and backend TypeScript typecheck — the same gates as GitHub Actions (`CI / check`).
+This runs Prettier check, frontend ESLint + build, and backend TypeScript typecheck — the same gates as the GitHub Actions `check` job.
 
 Individual steps:
 
@@ -43,7 +43,7 @@ On commit, Husky runs `lint-staged`, which auto-formats staged files with Pretti
 `main` is protected by the **Protect main** ruleset:
 
 - **No direct pushes to `main`** — use a PR
-- **`CI / check` must pass** before merge
+- **The `check` CI job must pass** before merge
 - **No force push** or branch deletion on `main`
 
 Typical workflow:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,25 +57,25 @@ Details: [`.github/BRANCH_PROTECTION.md`](.github/BRANCH_PROTECTION.md)
 
 ## Skills by topic
 
-| Topic | Guide |
-| ----- | ----- |
-| Local setup, formatting, CI, branch rules | [`skills/code-standards/SKILL.md`](skills/code-standards/SKILL.md) |
-| Commit, push, open PR | [`skills/pr-workflow/SKILL.md`](skills/pr-workflow/SKILL.md) |
-| React / Tailwind frontend | [`skills/frontend-conventions/SKILL.md`](skills/frontend-conventions/SKILL.md) |
-| API contract / mock flag | [`skills/backend-contract/SKILL.md`](skills/backend-contract/SKILL.md) |
-| UI component choice | [`skills/ui-components/SKILL.md`](skills/ui-components/SKILL.md) |
-| Transactions, filters, charts | [`skills/spend-analyzer-flow/SKILL.md`](skills/spend-analyzer-flow/SKILL.md) |
-| Profile gating | [`skills/profile-gating/SKILL.md`](skills/profile-gating/SKILL.md) |
+| Topic                                     | Guide                                                                          |
+| ----------------------------------------- | ------------------------------------------------------------------------------ |
+| Local setup, formatting, CI, branch rules | [`skills/code-standards/SKILL.md`](skills/code-standards/SKILL.md)             |
+| Commit, push, open PR                     | [`skills/pr-workflow/SKILL.md`](skills/pr-workflow/SKILL.md)                   |
+| React / Tailwind frontend                 | [`skills/frontend-conventions/SKILL.md`](skills/frontend-conventions/SKILL.md) |
+| API contract / mock flag                  | [`skills/backend-contract/SKILL.md`](skills/backend-contract/SKILL.md)         |
+| UI component choice                       | [`skills/ui-components/SKILL.md`](skills/ui-components/SKILL.md)               |
+| Transactions, filters, charts             | [`skills/spend-analyzer-flow/SKILL.md`](skills/spend-analyzer-flow/SKILL.md)   |
+| Profile gating                            | [`skills/profile-gating/SKILL.md`](skills/profile-gating/SKILL.md)             |
 
 ## Repo layout
 
-| Path | Purpose |
-| ---- | ------- |
-| `frontend/web/` | React + Vite app |
-| `backend/` | Hono API (Lambda + local dev) |
-| `package.json` (root) | Prettier, Husky, `npm run ci` |
-| `.github/workflows/ci.yml` | PR checks |
-| `skills/` | Project conventions and workflow guides |
+| Path                       | Purpose                                 |
+| -------------------------- | --------------------------------------- |
+| `frontend/web/`            | React + Vite app                        |
+| `backend/`                 | Hono API (Lambda + local dev)           |
+| `package.json` (root)      | Prettier, Husky, `npm run ci`           |
+| `.github/workflows/ci.yml` | PR checks                               |
+| `skills/`                  | Project conventions and workflow guides |
 
 ## Do not
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ On commit, Husky runs `lint-staged`, which auto-formats staged files with Pretti
 
 `main` is protected by the **Protect main** ruleset:
 
-- **No direct pushes to `main`** — use a PR (repo admins can bypass in emergencies)
+- **No direct pushes to `main`** — use a PR
 - **`CI / check` must pass** before merge
 - **No force push** or branch deletion on `main`
 
@@ -79,7 +79,7 @@ Details: [`.github/BRANCH_PROTECTION.md`](.github/BRANCH_PROTECTION.md)
 
 ## Do not
 
-- Push directly to `main` (unless you are bypassing as a repo admin)
+- Push directly to `main`
 - Skip hooks (`git commit --no-verify`) to bypass formatting or lint
 - Commit `.env` or secrets (only `.env.example` is tracked)
 - Add vendor or tool branding to commit messages or PR descriptions

--- a/skills/README.md
+++ b/skills/README.md
@@ -33,15 +33,15 @@ The `description` is the most important field — write it in the form _"X. Use 
 
 ## Skills in this repo
 
-| Skill                                                     | What it covers                                                               |
-| --------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| [`frontend-conventions`](./frontend-conventions/SKILL.md) | React 19 + Vite + Tailwind + framer-motion patterns used across the web app  |
-| [`backend-contract`](./backend-contract/SKILL.md)         | The schema-first FE/BE contract (`schema.json`, services, `VITE_USE_MOCK`)   |
-| [`ui-components`](./ui-components/SKILL.md)               | When to use which component (Card, Drawer, Select, KpiCard, CountUp, Avatar) |
-| [`spend-analyzer-flow`](./spend-analyzer-flow/SKILL.md)   | How transactions, filters, insights and charts wire together                 |
-| [`profile-gating`](./profile-gating/SKILL.md)             | Guest-first model: gating advanced features behind `hasProfile`              |
+| Skill                                                     | What it covers                                                                |
+| --------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| [`frontend-conventions`](./frontend-conventions/SKILL.md) | React 19 + Vite + Tailwind + framer-motion patterns used across the web app   |
+| [`backend-contract`](./backend-contract/SKILL.md)         | The schema-first FE/BE contract (`schema.json`, services, `VITE_USE_MOCK`)    |
+| [`ui-components`](./ui-components/SKILL.md)               | When to use which component (Card, Drawer, Select, KpiCard, CountUp, Avatar)  |
+| [`spend-analyzer-flow`](./spend-analyzer-flow/SKILL.md)   | How transactions, filters, insights and charts wire together                  |
+| [`profile-gating`](./profile-gating/SKILL.md)             | Guest-first model: gating advanced features behind `hasProfile`               |
 | [`code-standards`](./code-standards/SKILL.md)             | Local setup (`npm install`), Prettier, Husky, `npm run ci`, branch protection |
-| [`pr-workflow`](./pr-workflow/SKILL.md)                   | Lint, build, commit style and PR template                                    |
+| [`pr-workflow`](./pr-workflow/SKILL.md)                   | Lint, build, commit style and PR template                                     |
 
 ## Adding a new skill
 

--- a/skills/code-standards/SKILL.md
+++ b/skills/code-standards/SKILL.md
@@ -31,12 +31,12 @@ Editor setup (VS Code):
 
 ## Formatting config
 
-| File | Role |
-| ---- | ---- |
-| [`.prettierrc`](../../.prettierrc) | Prettier options (semicolons, double quotes, 100 cols) |
-| [`.prettierignore`](../../.prettierignore) | Ignores `node_modules`, `dist`, `archive`, lockfiles |
-| [`.editorconfig`](../../.editorconfig) | Basic editor defaults (2-space indent, LF, UTF-8) |
-| [`frontend/web/eslint.config.js`](../../frontend/web/eslint.config.js) | ESLint + `eslint-config-prettier` (no rule conflicts) |
+| File                                                                   | Role                                                   |
+| ---------------------------------------------------------------------- | ------------------------------------------------------ |
+| [`.prettierrc`](../../.prettierrc)                                     | Prettier options (semicolons, double quotes, 100 cols) |
+| [`.prettierignore`](../../.prettierignore)                             | Ignores `node_modules`, `dist`, `archive`, lockfiles   |
+| [`.editorconfig`](../../.editorconfig)                                 | Basic editor defaults (2-space indent, LF, UTF-8)      |
+| [`frontend/web/eslint.config.js`](../../frontend/web/eslint.config.js) | ESLint + `eslint-config-prettier` (no rule conflicts)  |
 
 ## Commands (always from repo root unless noted)
 
@@ -52,12 +52,12 @@ Run `npm run ci` before push or opening a PR. Fix failures locally — do not di
 
 ## What runs automatically
 
-| Trigger | Action |
-| ------- | ------ |
-| `git commit` | Husky → lint-staged → Prettier on staged files |
-| VS Code save | Prettier format (if extension installed) |
-| PR to `main` | GitHub Actions [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) |
-| Merge to `main` | Blocked until `CI / check` passes |
+| Trigger         | Action                                                                      |
+| --------------- | --------------------------------------------------------------------------- |
+| `git commit`    | Husky → lint-staged → Prettier on staged files                              |
+| VS Code save    | Prettier format (if extension installed)                                    |
+| PR to `main`    | GitHub Actions [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) |
+| Merge to `main` | Blocked until `CI / check` passes                                           |
 
 ## Branch protection (GitHub)
 

--- a/skills/code-standards/SKILL.md
+++ b/skills/code-standards/SKILL.md
@@ -57,14 +57,14 @@ Run `npm run ci` before push or opening a PR. Fix failures locally — do not di
 | `git commit`    | Husky → lint-staged → Prettier on staged files                              |
 | VS Code save    | Prettier format (if extension installed)                                    |
 | PR to `main`    | GitHub Actions [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) |
-| Merge to `main` | Blocked until `CI / check` passes                                           |
+| Merge to `main` | Blocked until the `check` CI job passes                                     |
 
 ## Branch protection (GitHub)
 
 The **Protect main** ruleset is active on `Oblivion-Labs-Dev/FinanceOS`:
 
 - Pull requests required (no direct pushes to `main`)
-- Required status check: `CI / check`
+- Required status check: `check` (GitHub Actions CI workflow)
 - Force push and branch deletion blocked on `main`
 
 Contributors should:
@@ -89,7 +89,7 @@ Human-readable notes: [`.github/BRANCH_PROTECTION.md`](../../.github/BRANCH_PROT
 2. Work on a feature branch, not `main`
 3. Before commit: staged files will auto-format via Husky
 4. Before push/PR: `npm run ci` from repo root
-5. Open PR to `main`; do not merge until `CI / check` is green
+5. Open PR to `main`; do not merge until the `check` job is green
 
 ## Related guides
 

--- a/skills/pr-workflow/SKILL.md
+++ b/skills/pr-workflow/SKILL.md
@@ -29,7 +29,7 @@ From the **repo root**, run the full CI pipeline:
 npm run ci
 ```
 
-This matches GitHub Actions (`CI / check`): Prettier check, frontend lint + build, backend typecheck.
+This matches the GitHub Actions `check` job: Prettier check, frontend lint + build, backend typecheck.
 
 Husky auto-formats staged files on commit; still run `npm run ci` before push to catch issues early.
 


### PR DESCRIPTION
## Summary
- Removes repository admin bypass from the **Protect main** ruleset
- Pins required status check to GitHub Actions `CI / check` (integration_id 15368)
- Updates contributor docs; merge is blocked until CI passes

## Test plan
- [ ] CI / check passes on this PR
- [ ] Merge button stays disabled until CI is green